### PR TITLE
Aanpassen links m.n. naar 2017, 2018 en 2019 edities

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ organizerAlternateName: "Open Source Geo Nederland"
 organizerDescription: "..."
 organizerEmail: "foss4g@osgeo.nl"
 organizerLogo: "/img/seo/organizer-logo.png"
-organizerLink: "http://www.osgeo.nl/"
+organizerLink: "https://osgeo.nl/"
 
 # Head
 metaKeywords: "event, osgeo, conferentie, open source, geo, gis, enschede, geographic, nederland"
@@ -125,8 +125,9 @@ footerBlocks:
   links:
    - {link: "https://osgeo.nl/", text: "OSGeo.nl"}
    - {link: "https://wiki.osgeo.org/wiki/Nederlands/", text: "Wiki"}
-   - {link: "http://foss4g.nl/history/2017/", text: "FOSS4GNL 2017"}
-   - {link: "http://foss4gnl.github.io", text: "FOSS4GNL 2018"}
+   - {link: "https://2017.foss4g.nl", text: "FOSS4GNL 2017"}
+   - {link: "https://2018.foss4g.nl", text: "FOSS4GNL 2018"}
+   - {link: "https://2019.foss4g.nl", text: "FOSS4GNL 2019"}
  -
   title: "Contact"
   links:


### PR DESCRIPTION
Deze edities hebben eigen repo+site nu: dus 
https://2017.osgeo.nl https://2018.osgeo.nl https://2019.osgeo.nl